### PR TITLE
Enable login check before showing main tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The app communicates with the MakerWorks backend at `https://api.makerworks.app`
 ## Build and Run
 1. Open `MakerWorks.xcodeproj` in Xcode.
 2. Select the `MakerWorks` target and your preferred simulator or device.
-3. Build and run the app with **Cmd+R** or by pressing the Run button.
+3. Build and run the app with **Cmd+R** or by pressing the Run button. The app
+   checks if you are already authenticated and shows the login screen if not.
 
 Alternatively, use `xcodebuild` on the command line:
 ```sh

--- a/Sources/App/MakerWorksApp.swift
+++ b/Sources/App/MakerWorksApp.swift
@@ -9,9 +9,27 @@ import SwiftUI
 
 @main
 struct MakerWorksApp: App {
+    @StateObject private var authViewModel = AuthViewModel()
+
     var body: some Scene {
         WindowGroup {
-            RootView()
+            Group {
+                if authViewModel.isAuthenticated {
+                    RootView()
+                        .environmentObject(authViewModel)
+                } else {
+                    LoginView()
+                }
+            }
+            .onAppear {
+                authViewModel.checkAuth()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .didLogin)) { _ in
+                authViewModel.checkAuth()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .didLogout)) { _ in
+                authViewModel.logout()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- gate RootView behind authentication in `MakerWorksApp`
- document login requirement in README

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6870535e5858832f8e4faa33c8102471

## Summary by Sourcery

Require users to authenticate before displaying the main tabs by introducing AuthViewModel, displaying LoginView when unauthenticated, and handling auth state changes on launch and login/logout events.

New Features:
- Gate main app interface behind authentication with a login screen

Enhancements:
- Add AuthViewModel as a state object and inject it into the environment
- Refresh authentication status on app launch and in response to login/logout notifications

Documentation:
- Update README to note the login requirement before running the app