### PR TITLE
Add landing screen for server address

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MakerWorks-iOS is a SwiftUI application for interacting with the MakerWorks service. The project contains network clients, view models, and views for authentication, browsing models, requesting estimates, and uploading prints.
 
-The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. Update `DefaultNetworkClient` if you need to target a different API host.
+The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. On first launch you will be prompted for the server address and the value entered will be used for all API requests. You can still update the base URL programmatically via `DefaultNetworkClient` if needed.
 
 ## Prerequisites
 - macOS with [Xcode](https://developer.apple.com/xcode/) **16.3** or later

--- a/Sources/App/MakerWorksApp.swift
+++ b/Sources/App/MakerWorksApp.swift
@@ -9,9 +9,26 @@ import SwiftUI
 
 @main
 struct MakerWorksApp: App {
+    @AppStorage("serverAddress") private var serverAddress: String?
+    @State private var isLoggedIn: Bool = false
+
     var body: some Scene {
         WindowGroup {
-            RootView()
+            if serverAddress == nil {
+                LandingView()
+            } else if !isLoggedIn {
+                LoginView()
+                    .onAppear {
+                        if let addr = serverAddress, let url = URL(string: addr) {
+                            DefaultNetworkClient.shared.updateBaseURL(url)
+                        }
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: .didLogin)) { _ in
+                        isLoggedIn = true
+                    }
+            } else {
+                RootView()
+            }
         }
     }
 }

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -25,7 +25,7 @@ final class DefaultNetworkClient: NetworkClient {
     ///
     /// This is exposed so that other modules can build URLs or requests
     /// without needing to duplicate the base URL string.
-    let baseURL: URL
+    private(set) var baseURL: URL
     private let session: URLSession
     private let authenticator: Authenticator
 
@@ -33,6 +33,11 @@ final class DefaultNetworkClient: NetworkClient {
         self.baseURL = baseURL
         self.session = session
         self.authenticator = authenticator
+    }
+
+    /// Updates the base URL for subsequent requests
+    func updateBaseURL(_ url: URL) {
+        self.baseURL = url
     }
 
     func request<T: Decodable>(_ endpoint: APIEndpoint) -> AnyPublisher<T, Error> {

--- a/Sources/Tests/MakerWorksTests/NetworkClientTests.swift
+++ b/Sources/Tests/MakerWorksTests/NetworkClientTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import MakerWorks
+
+final class NetworkClientTests: XCTestCase {
+    func testUpdateBaseURL() {
+        let initialURL = URL(string: "https://example.com")!
+        let client = DefaultNetworkClient(baseURL: initialURL, authenticator: Authenticator.shared)
+        let newURL = URL(string: "https://new.example.com")!
+        client.updateBaseURL(newURL)
+        XCTAssertEqual(client.baseURL, newURL)
+    }
+}

--- a/Sources/Views/LandingView.swift
+++ b/Sources/Views/LandingView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct LandingView: View {
+    @AppStorage("serverAddress") private var serverAddress: String?
+    @State private var address: String = ""
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.8).edgesIgnoringSafeArea(.all)
+            VStack(spacing: 24) {
+                Spacer()
+                Text("Enter Server Address")
+                    .font(.largeTitle)
+                    .foregroundColor(.white)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+
+                TextField("https://myserver.com", text: $address)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
+                Button("Continue") {
+                    if let url = URL(string: address) {
+                        DefaultNetworkClient.shared.updateBaseURL(url)
+                        serverAddress = address
+                    }
+                }
+                .disabled(address.isEmpty)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(.ultraThinMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 20))
+                .padding(.horizontal)
+
+                Spacer()
+            }
+        }
+        .onAppear {
+            address = serverAddress ?? "https://api.makerworks.app"
+        }
+    }
+}
+
+#if DEBUG
+struct LandingView_Previews: PreviewProvider {
+    static var previews: some View {
+        LandingView()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- create `LandingView` to collect the server address from the user on first launch
- update `MakerWorksApp` to show the landing view, login view, or main tabs depending on state
- allow `DefaultNetworkClient` to update its base URL at runtime
- document new behaviour in README
- add `NetworkClientTests` to cover base URL updates

## Testing
- `swift test` *(fails: `Could not find Package.swift`)*

------
https://chatgpt.com/codex/tasks/task_e_68711a33ca28832f8b79581070b4d203