### PR TITLE
Implement credential-based login

### DIFF
--- a/Sources/Networking/APIEndpoint.swift
+++ b/Sources/Networking/APIEndpoint.swift
@@ -8,12 +8,16 @@
 import Foundation
 
 enum APIEndpoint {
+    case signup(email: String, password: String)
+    case signin(email: String, password: String)
+    case login(username: String, password: String)
     case currentUser
+    case debugMe
+    case adminUnlock(email: String)
     case uploadModel
     case listModels
     case estimate
     case exchangeCode(String)
-    case login
     case logout
     // … add more cases as you implement other endpoints
 
@@ -22,10 +26,47 @@ enum APIEndpoint {
         var request: URLRequest
 
         switch self {
+        case let .signup(email, password):
+            url = baseURL.appendingPathComponent("/api/v1/auth/signup")
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body = ["email": email, "password": password]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+
+        case let .signin(email, password):
+            url = baseURL.appendingPathComponent("/api/v1/auth/signin")
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body = ["email": email, "password": password]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+
+        case let .login(username, password):
+            url = baseURL.appendingPathComponent("/api/v1/auth/login")
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body = ["username": username, "password": password]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
+
         case .currentUser:
             url = baseURL.appendingPathComponent("/api/v1/auth/me")
             request = URLRequest(url: url)
             request.httpMethod = "GET"
+
+        case .debugMe:
+            url = baseURL.appendingPathComponent("/api/v1/auth/debug")
+            request = URLRequest(url: url)
+            request.httpMethod = "GET"
+
+        case let .adminUnlock(email):
+            url = baseURL.appendingPathComponent("/api/v1/auth/admin/unlock")
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body = ["email": email]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
 
         case .uploadModel:
             url = baseURL.appendingPathComponent("/api/v1/upload/")
@@ -49,11 +90,6 @@ enum APIEndpoint {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             let body = ["code": code]
             request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
-
-        case .login:
-            url = baseURL.appendingPathComponent("/api/v1/auth/login")
-            request = URLRequest(url: url)
-            request.httpMethod = "POST"
 
         case .logout:
             url = baseURL.appendingPathComponent("/api/v1/auth/logout")

--- a/Sources/Networking/AuthService.swift
+++ b/Sources/Networking/AuthService.swift
@@ -11,6 +11,11 @@ import Combine
 protocol AuthServiceProtocol {
     func fetchCurrentUser() -> AnyPublisher<User, Error>
     func exchangeCodeForToken(code: String) -> AnyPublisher<User, Error>
+    func login(username: String, password: String) -> AnyPublisher<User, Error>
+    func signup(email: String, password: String) -> AnyPublisher<User, Error>
+    func signin(email: String, password: String) -> AnyPublisher<User, Error>
+    func debugMe() -> AnyPublisher<User, Error>
+    func adminUnlock(email: String) -> AnyPublisher<Void, Error>
     func logout()
 }
 
@@ -29,6 +34,26 @@ final class AuthService: AuthServiceProtocol {
     /// Exchange OIDC authorization code for tokens & fetch user
     func exchangeCodeForToken(code: String) -> AnyPublisher<User, Error> {
         client.request(.exchangeCode(code))
+    }
+
+    func login(username: String, password: String) -> AnyPublisher<User, Error> {
+        client.request(.login(username: username, password: password))
+    }
+
+    func signup(email: String, password: String) -> AnyPublisher<User, Error> {
+        client.request(.signup(email: email, password: password))
+    }
+
+    func signin(email: String, password: String) -> AnyPublisher<User, Error> {
+        client.request(.signin(email: email, password: password))
+    }
+
+    func debugMe() -> AnyPublisher<User, Error> {
+        client.request(.debugMe)
+    }
+
+    func adminUnlock(email: String) -> AnyPublisher<Void, Error> {
+        client.request(.adminUnlock(email: email))
     }
 
     /// Logs out the user and clears token storage

--- a/Sources/Views/LoginView.swift
+++ b/Sources/Views/LoginView.swift
@@ -27,10 +27,20 @@ struct LoginView: View {
                         .padding()
                 }
 
+                TextField("Username", text: $viewModel.username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
+                SecureField("Password", text: $viewModel.password)
+                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                    .padding(.horizontal)
+
                 Button(action: {
                     viewModel.login()
                 }) {
-                    Text(viewModel.isLoading ? "Logging in…" : "Login with MakerWorks")
+                    Text(viewModel.isLoading ? "Logging in…" : "Login")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(.ultraThinMaterial)


### PR DESCRIPTION
## Summary
- support new authentication endpoints
- implement credential-based login flow
- add username and password fields to the login view

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687127ed68c4832f9856a81e47403950