### PR TITLE
Add parameters to estimate endpoint

### DIFF
--- a/Sources/Models/EstimateParameters.swift
+++ b/Sources/Models/EstimateParameters.swift
@@ -1,0 +1,20 @@
+//
+//  EstimateParameters.swift
+//  MakerWorks
+//
+//  Created by OpenAI Codex on 2025-07-06.
+//
+
+import Foundation
+
+/// Request body for the estimate endpoint
+struct EstimateParameters: Codable {
+    let model_id: Int
+    let x_mm: Double
+    let y_mm: Double
+    let z_mm: Double
+    let filament_type: String
+    let filament_colors: [String]
+    let print_profile: String
+    let custom_text: String?
+}

--- a/Sources/Networking/APIEndpoint.swift
+++ b/Sources/Networking/APIEndpoint.swift
@@ -16,7 +16,7 @@ enum APIEndpoint {
     case adminUnlock(email: String)
     case uploadModel
     case listModels
-    case estimate
+    case estimate(parameters: EstimateParameters)
     case exchangeCode(String)
     case logout
     // … add more cases as you implement other endpoints
@@ -78,10 +78,13 @@ enum APIEndpoint {
             request = URLRequest(url: url)
             request.httpMethod = "GET"
 
-        case .estimate:
+        case let .estimate(parameters):
             url = baseURL.appendingPathComponent("/api/v1/estimate/estimates/")
             request = URLRequest(url: url)
             request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let encoder = JSONEncoder()
+            request.httpBody = try? encoder.encode(parameters)
 
         case .exchangeCode(let code):
             url = baseURL.appendingPathComponent("/api/v1/auth/exchange/")


### PR DESCRIPTION
## Summary
- add `EstimateParameters` request model
- update `APIEndpoint` with `.estimate(parameters:)`
- use network client for estimating in `EstimateViewModel`

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687287c08340832f9255a18a6c8b2424