### PR TITLE
Add basic login UI test

### DIFF
--- a/Sources/Tests/MakerWorksUITests/LoginUITests.swift
+++ b/Sources/Tests/MakerWorksUITests/LoginUITests.swift
@@ -5,3 +5,24 @@
 //  Created by Stephen Chartrand on 2025-07-06.
 //
 
+import XCTest
+
+final class LoginUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    /// Verifies that all basic login screen elements are present when the app launches.
+    func testLoginScreenElementsExist() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Welcome to MakerWorks"].exists)
+        XCTAssertTrue(app.textFields["Server Address"].exists)
+        XCTAssertTrue(app.textFields["Username"].exists)
+        XCTAssertTrue(app.secureTextFields["Password"].exists)
+        XCTAssertTrue(app.buttons["Login"].exists)
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- add a simple UI test verifying login screen elements

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728b08925c832f8c01d84e1d6ef71a

## Summary by Sourcery

Tests:
- Add UI test verifying that the welcome text, server address, username field, password field, and login button exist