### PR TITLE
Replace NavigationView with NavigationStack

### DIFF
--- a/Sources/Views/BrowseView.swift
+++ b/Sources/Views/BrowseView.swift
@@ -11,7 +11,7 @@ struct BrowseView: View {
     @StateObject private var viewModel = BrowseViewModel()
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 if viewModel.isLoading {
                     ProgressView("Loading models…")

--- a/Sources/Views/DashboardView.swift
+++ b/Sources/Views/DashboardView.swift
@@ -11,7 +11,7 @@ struct DashboardView: View {
     @StateObject private var viewModel = DashboardViewModel()
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 20) {
                 Text("Welcome, \(viewModel.user?.username ?? "Maker")!")
                     .font(.title)

--- a/Sources/Views/EstimateView.swift
+++ b/Sources/Views/EstimateView.swift
@@ -11,7 +11,7 @@ struct EstimateView: View {
     @StateObject private var viewModel = EstimateViewModel()
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: 20) {
                     Text("Estimate Your Print")


### PR DESCRIPTION
## Summary
- use `NavigationStack` instead of deprecated `NavigationView` in BrowseView, DashboardView, and EstimateView

## Testing
- `swiftc -parse Sources/Views/BrowseView.swift`
- `swiftc -parse Sources/Views/DashboardView.swift`
- `swiftc -parse Sources/Views/EstimateView.swift`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68728bd32de0832fb26452d148101724