### PR TITLE
Add Favorites feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MakerWorks iOS
 
-MakerWorks-iOS is a SwiftUI application for interacting with the MakerWorks service. The project contains network clients, view models, and views for authentication, browsing models, requesting estimates, and uploading prints.
+MakerWorks-iOS is a SwiftUI application for interacting with the MakerWorks service. The project contains network clients, view models, and views for authentication, browsing models, requesting estimates, uploading prints, and managing local favorites.
 
 The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. The login screen includes a field for the server address and the value entered will be used for all API requests. You can still update the base URL programmatically via `DefaultNetworkClient` if needed.
 
@@ -25,6 +25,9 @@ To run the tests from the command line:
 ```sh
 xcodebuild -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 15' test
 ```
+
+## Favorites
+Models can be marked as favorites locally. Use the star button on a model card to toggle the favorite state. The **Favorites** tab lists all favorited models.
 
 ## Beta Testing
 To distribute beta builds via TestFlight:

--- a/Sources/Models/FavoritesManager.swift
+++ b/Sources/Models/FavoritesManager.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Stores favorite model IDs using UserDefaults
+final class FavoritesManager: ObservableObject {
+    static let shared = FavoritesManager()
+
+    @Published private(set) var favorites: Set<Int>
+    private let defaults = UserDefaults.standard
+    private let key = "favoriteModelIDs"
+
+    private init() {
+        let saved = defaults.array(forKey: key) as? [Int] ?? []
+        favorites = Set(saved)
+    }
+
+    func toggle(id: Int) {
+        if favorites.contains(id) {
+            favorites.remove(id)
+        } else {
+            favorites.insert(id)
+        }
+        defaults.set(Array(favorites), forKey: key)
+    }
+
+    func isFavorite(id: Int) -> Bool {
+        favorites.contains(id)
+    }
+}

--- a/Sources/Tests/MakerWorksTests/FavoritesManagerTests.swift
+++ b/Sources/Tests/MakerWorksTests/FavoritesManagerTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import MakerWorks
+
+final class FavoritesManagerTests: XCTestCase {
+    override func tearDown() {
+        FavoritesManager.shared.favorites.removeAll()
+        UserDefaults.standard.removeObject(forKey: "favoriteModelIDs")
+        super.tearDown()
+    }
+
+    func testToggleFavorite() {
+        FavoritesManager.shared.toggle(id: 1)
+        XCTAssertTrue(FavoritesManager.shared.isFavorite(id: 1))
+        FavoritesManager.shared.toggle(id: 1)
+        XCTAssertFalse(FavoritesManager.shared.isFavorite(id: 1))
+    }
+
+    func testPersistence() {
+        FavoritesManager.shared.toggle(id: 2)
+        let newManager = FavoritesManager.shared
+        XCTAssertTrue(newManager.isFavorite(id: 2))
+    }
+}

--- a/Sources/ViewModels/DashboardViewModel.swift
+++ b/Sources/ViewModels/DashboardViewModel.swift
@@ -43,4 +43,5 @@ final class DashboardViewModel: ObservableObject {
 
 extension Notification.Name {
     static let didLogout = Notification.Name("didLogout")
+    static let showFavorites = Notification.Name("showFavorites")
 }

--- a/Sources/ViewModels/FavoritesViewModel.swift
+++ b/Sources/ViewModels/FavoritesViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Combine
+
+final class FavoritesViewModel: ObservableObject {
+    @Published var models: [Model] = []
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    private var cancellables = Set<AnyCancellable>()
+    private let client: NetworkClient
+    private let favoritesManager: FavoritesManager
+
+    init(client: NetworkClient = DefaultNetworkClient.shared,
+         favoritesManager: FavoritesManager = .shared) {
+        self.client = client
+        self.favoritesManager = favoritesManager
+    }
+
+    func fetchFavoriteModels() {
+        isLoading = true
+        errorMessage = nil
+
+        client.request(.listModels)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                guard let self = self else { return }
+                self.isLoading = false
+                if case .failure(let error) = completion {
+                    self.errorMessage = error.localizedDescription
+                }
+            }, receiveValue: { [weak self] (allModels: [Model]) in
+                guard let self = self else { return }
+                let ids = self.favoritesManager.favorites
+                self.models = allModels.filter { ids.contains($0.id) }
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/Views/DashboardView.swift
+++ b/Sources/Views/DashboardView.swift
@@ -32,7 +32,8 @@ struct DashboardView: View {
                         }
 
                         Button("View Favorites") {
-                            // Navigate to Favorites
+                            // Switch to Favorites tab
+                            NotificationCenter.default.post(name: .showFavorites, object: nil)
                         }
 
                         Button("Log Out") {

--- a/Sources/Views/FavoritesView.swift
+++ b/Sources/Views/FavoritesView.swift
@@ -1,24 +1,21 @@
-//
-//  BrowseView.swift
-//  MakerWorks
-//
-//  Created by Stephen Chartrand on 2025-07-06.
-//
-
 import SwiftUI
 
-struct BrowseView: View {
-    @StateObject private var viewModel = BrowseViewModel()
+struct FavoritesView: View {
+    @StateObject private var viewModel = FavoritesViewModel()
 
     var body: some View {
         NavigationStack {
             VStack {
                 if viewModel.isLoading {
-                    ProgressView("Loading models…")
+                    ProgressView("Loading favorites…")
                         .progressViewStyle(CircularProgressViewStyle())
                 } else if let error = viewModel.errorMessage {
                     Text("Error: \(error)")
                         .foregroundColor(.red)
+                        .padding()
+                } else if viewModel.models.isEmpty {
+                    Text("No favorites yet")
+                        .foregroundColor(.secondary)
                         .padding()
                 } else {
                     List(viewModel.models) { model in
@@ -29,23 +26,10 @@ struct BrowseView: View {
                                 Spacer()
                                 FavoriteButton(modelID: model.id)
                             }
-
                             if let description = model.description {
                                 Text(description)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
-                            }
-
-                            HStack {
-                                Text("Uploader: \(model.uploader)")
-                                    .font(.caption)
-                                    .foregroundColor(.gray)
-
-                                Spacer()
-
-                                Text(viewModel.formatDate(model.uploadedAt))
-                                    .font(.caption)
-                                    .foregroundColor(.gray)
                             }
                         }
                         .liquidGlass()
@@ -55,14 +39,14 @@ struct BrowseView: View {
                     .listStyle(PlainListStyle())
                 }
             }
-            .navigationTitle("Browse Models")
+            .navigationTitle("Favorites")
             .onAppear {
-                viewModel.fetchModels()
+                viewModel.fetchFavoriteModels()
             }
         }
     }
 }
 
 #Preview {
-    BrowseView()
+    FavoritesView()
 }

--- a/Sources/Views/RootView.swift
+++ b/Sources/Views/RootView.swift
@@ -1,22 +1,36 @@
 import SwiftUI
 
 struct RootView: View {
+    @State private var selection = 0
+
     var body: some View {
-        TabView {
+        TabView(selection: $selection) {
             BrowseView()
                 .tabItem {
                     Label("Browse", systemImage: "cube.box")
                 }
+                .tag(0)
+
+            FavoritesView()
+                .tabItem {
+                    Label("Favorites", systemImage: "star.fill")
+                }
+                .tag(1)
 
             DashboardView()
                 .tabItem {
                     Label("Dashboard", systemImage: "person.crop.circle")
                 }
+                .tag(2)
 
             EstimateView()
                 .tabItem {
                     Label("Estimate", systemImage: "ruler.fill")
                 }
+                .tag(3)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .showFavorites)) { _ in
+            selection = 1
         }
     }
 }

--- a/Sources/Views/components/FavoriteButton.swift
+++ b/Sources/Views/components/FavoriteButton.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct FavoriteButton: View {
+    let modelID: Int
+    @ObservedObject var manager: FavoritesManager = .shared
+
+    var body: some View {
+        Button(action: {
+            manager.toggle(id: modelID)
+        }) {
+            Image(systemName: manager.isFavorite(id: modelID) ? "star.fill" : "star")
+                .foregroundColor(.yellow)
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+#Preview {
+    FavoriteButton(modelID: 1)
+}


### PR DESCRIPTION
## Summary
- add local Favorites feature via `FavoritesManager`
- support viewing favorites and toggling with a star button
- add `FavoritesViewModel` and `FavoritesView`
- hook favorites into `RootView` and `DashboardView`
- test coverage for `FavoritesManager`
- document favorites in README

## Testing
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d87195aa0832f9d1a4a042c34bd1d

## Summary by Sourcery

Implement a local favorites feature that lets users star models, view them in a dedicated Favorites tab, and persist selections across app launches.

New Features:
- Add FavoritesManager for storing favorite model IDs in UserDefaults
- Create FavoriteButton component for toggling favorite status
- Introduce FavoritesView and FavoritesViewModel to display favorited models in a new tab
- Enable navigation to the Favorites tab via a notification from the Dashboard

Enhancements:
- Update RootView TabView to track selected tab and respond to showFavorites notifications

Documentation:
- Document the Favorites feature in README

Tests:
- Add unit tests for FavoritesManager to verify toggling and persistence of favorites