### PR TITLE
Point dev app to localhost backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MakerWorks-iOS is a SwiftUI application for interacting with the MakerWorks service. The project contains network clients, view models, and views for authentication, browsing models, requesting estimates, uploading prints, and managing local favorites.
 
-The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. The login screen includes a field for the server address and the value entered will be used for all API requests. You can still update the base URL programmatically via `DefaultNetworkClient` if needed.
+The app communicates with the MakerWorks backend at `http://localhost:8000` by default. The login screen includes a field for the server address and the value entered will be used for all API requests. You can still update the base URL programmatically via `DefaultNetworkClient` if needed.
 
 ## Prerequisites
 - macOS with [Xcode](https://developer.apple.com/xcode/) **16.3** or later

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -17,7 +17,7 @@ protocol NetworkClient {
 /// Default implementation of the NetworkClient
 final class DefaultNetworkClient: NetworkClient {
     static let shared = DefaultNetworkClient(
-        baseURL: URL(string: "https://api.makerworks.app")!,
+        baseURL: URL(string: "http://localhost:8000")!,
         authenticator: Authenticator.shared
     )
 

--- a/Sources/Tests/MakerWorksTests/AuthTests.swift
+++ b/Sources/Tests/MakerWorksTests/AuthTests.swift
@@ -3,11 +3,11 @@ import XCTest
 
 final class AuthTests: XCTestCase {
     func testExchangeCodeEndpointRequest() throws {
-        let baseURL = URL(string: "https://api.makerworks.app")!
+        let baseURL = URL(string: "http://localhost:8000")!
         let request = APIEndpoint.exchangeCode("abc123").urlRequest(baseURL: baseURL)
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(request.url?.absoluteString, "https://api.makerworks.app/api/v1/auth/exchange/")
+        XCTAssertEqual(request.url?.absoluteString, "http://localhost:8000/api/v1/auth/exchange/")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
 
         if let body = request.httpBody,

--- a/Sources/Tests/MakerWorksTests/UploadEndpointTests.swift
+++ b/Sources/Tests/MakerWorksTests/UploadEndpointTests.swift
@@ -3,13 +3,13 @@ import XCTest
 
 final class UploadEndpointTests: XCTestCase {
     func testUploadRequest() throws {
-        let baseURL = URL(string: "https://api.makerworks.app")!
+        let baseURL = URL(string: "http://localhost:8000")!
         let data = "hello".data(using: .utf8)!
         let boundary = "XYZ"
         let request = APIEndpoint.uploadModel(data: data, boundary: boundary).urlRequest(baseURL: baseURL)
 
         XCTAssertEqual(request.httpMethod, "POST")
-        XCTAssertEqual(request.url?.absoluteString, "https://api.makerworks.app/api/v1/upload/")
+        XCTAssertEqual(request.url?.absoluteString, "http://localhost:8000/api/v1/upload/")
         XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "multipart/form-data; boundary=\(boundary)")
         XCTAssertEqual(request.httpBody, data)
     }

--- a/Sources/Views/LoginView.swift
+++ b/Sources/Views/LoginView.swift
@@ -66,7 +66,7 @@ struct LoginView: View {
             .padding()
         }
         .onAppear {
-            address = serverAddress ?? "https://api.makerworks.app"
+            address = serverAddress ?? "http://localhost:8000"
             if let addr = serverAddress, let url = URL(string: addr) {
                 DefaultNetworkClient.shared.updateBaseURL(url)
             }


### PR DESCRIPTION
## Summary
- switch default base URL to `http://localhost:8000`
- update login screen to use local server
- update tests for new default URL
- document localhost backend in README

## Testing
- `swift --version`
- `xcodebuild -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8d748e20832f9799c401e9347323