### PR TITLE
Align auth endpoints with backend

### DIFF
--- a/Sources/Networking/APIEndpoint.swift
+++ b/Sources/Networking/APIEndpoint.swift
@@ -10,7 +10,6 @@ import Foundation
 enum APIEndpoint {
     case signup(email: String, password: String)
     case signin(email: String, password: String)
-    case login(username: String, password: String)
     case currentUser
     case debugMe
     case adminUnlock(email: String)
@@ -18,7 +17,7 @@ enum APIEndpoint {
     case listModels
     case estimate(parameters: EstimateParameters)
     case exchangeCode(String)
-    case logout
+    case signout
     // … add more cases as you implement other endpoints
 
     func urlRequest(baseURL: URL) -> URLRequest {
@@ -42,14 +41,6 @@ enum APIEndpoint {
             let body = ["email": email, "password": password]
             request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
 
-        case let .login(username, password):
-            url = baseURL.appendingPathComponent("/api/v1/auth/login")
-            request = URLRequest(url: url)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            let body = ["username": username, "password": password]
-            request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
-
         case .currentUser:
             url = baseURL.appendingPathComponent("/api/v1/auth/me")
             request = URLRequest(url: url)
@@ -61,7 +52,7 @@ enum APIEndpoint {
             request.httpMethod = "GET"
 
         case let .adminUnlock(email):
-            url = baseURL.appendingPathComponent("/api/v1/auth/admin/unlock")
+            url = baseURL.appendingPathComponent("/api/v1/admin/admin/unlock")
             request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -96,8 +87,8 @@ enum APIEndpoint {
             let body = ["code": code]
             request.httpBody = try? JSONSerialization.data(withJSONObject: body, options: [])
 
-        case .logout:
-            url = baseURL.appendingPathComponent("/api/v1/auth/logout")
+        case .signout:
+            url = baseURL.appendingPathComponent("/api/v1/auth/signout")
             request = URLRequest(url: url)
             request.httpMethod = "POST"
         }

--- a/Sources/Networking/AuthService.swift
+++ b/Sources/Networking/AuthService.swift
@@ -11,12 +11,11 @@ import Combine
 protocol AuthServiceProtocol {
     func fetchCurrentUser() -> AnyPublisher<User, Error>
     func exchangeCodeForToken(code: String) -> AnyPublisher<User, Error>
-    func login(username: String, password: String) -> AnyPublisher<User, Error>
     func signup(email: String, password: String) -> AnyPublisher<User, Error>
     func signin(email: String, password: String) -> AnyPublisher<User, Error>
     func debugMe() -> AnyPublisher<User, Error>
     func adminUnlock(email: String) -> AnyPublisher<Void, Error>
-    func logout()
+    func signout()
 }
 
 final class AuthService: AuthServiceProtocol {
@@ -36,10 +35,6 @@ final class AuthService: AuthServiceProtocol {
         client.request(.exchangeCode(code))
     }
 
-    func login(username: String, password: String) -> AnyPublisher<User, Error> {
-        client.request(.login(username: username, password: password))
-    }
-
     func signup(email: String, password: String) -> AnyPublisher<User, Error> {
         client.request(.signup(email: email, password: password))
     }
@@ -56,8 +51,8 @@ final class AuthService: AuthServiceProtocol {
         client.request(.adminUnlock(email: email))
     }
 
-    /// Logs out the user and clears token storage
-    func logout() {
+    /// Signs out the user and clears token storage
+    func signout() {
         TokenStorage.shared.clear()
     }
 }

--- a/Sources/Tests/MakerWorksUITests/LoginUITests.swift
+++ b/Sources/Tests/MakerWorksUITests/LoginUITests.swift
@@ -19,9 +19,9 @@ final class LoginUITests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["Welcome to MakerWorks"].exists)
         XCTAssertTrue(app.textFields["Server Address"].exists)
-        XCTAssertTrue(app.textFields["Username"].exists)
+        XCTAssertTrue(app.textFields["Email"].exists)
         XCTAssertTrue(app.secureTextFields["Password"].exists)
-        XCTAssertTrue(app.buttons["Login"].exists)
+        XCTAssertTrue(app.buttons["Sign In"].exists)
     }
 }
 

--- a/Sources/ViewModels/AuthViewModel.swift
+++ b/Sources/ViewModels/AuthViewModel.swift
@@ -57,10 +57,10 @@ final class AuthViewModel: ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Logs out the current user.
-    func logout() {
-        logger.info("Logging out user.")
-        authService.logout()
+    /// Signs out the current user.
+    func signout() {
+        logger.info("Signing out user.")
+        authService.signout()
         isAuthenticated = false
         user = nil
         errorMessage = nil

--- a/Sources/ViewModels/LoginViewModel.swift
+++ b/Sources/ViewModels/LoginViewModel.swift
@@ -10,7 +10,7 @@ import Combine
 import os
 
 final class LoginViewModel: ObservableObject {
-    @Published var username: String = ""
+    @Published var email: String = ""
     @Published var password: String = ""
     @Published var isLoading: Bool = false
     @Published var errorMessage: String?
@@ -23,27 +23,27 @@ final class LoginViewModel: ObservableObject {
         self.authService = authService
     }
 
-    /// Starts the login process with username & password
-    func login() {
-        logger.info("Attempting login")
+    /// Starts the sign-in process with email & password
+    func signin() {
+        logger.info("Attempting sign in")
         self.isLoading = true
         self.errorMessage = nil
-        authService.login(username: username, password: password)
+        authService.signin(email: email, password: password)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { [weak self] completion in
                 guard let self = self else { return }
                 self.isLoading = false
                 if case .failure(let error) = completion {
                     self.errorMessage = error.localizedDescription
-                    self.logger.error("Login failed: \(error.localizedDescription)")
+                    self.logger.error("Sign in failed: \(error.localizedDescription)")
                 }
             }, receiveValue: { [weak self] user in
                 guard let self = self else { return }
                 self.isLoading = false
                 if let uuid = UUID(uuidString: user.id) {
-                    self.logger.info("Login successful: \(uuid.uuidString)")
+                    self.logger.info("Sign in successful: \(uuid.uuidString)")
                 } else {
-                    self.logger.info("Login successful: \(user.id)")
+                    self.logger.info("Sign in successful: \(user.id)")
                 }
                 NotificationCenter.default.post(name: .didLogin, object: nil)
             })

--- a/Sources/Views/LoginView.swift
+++ b/Sources/Views/LoginView.swift
@@ -35,7 +35,7 @@ struct LoginView: View {
                         .padding()
                 }
 
-                TextField("Username", text: $viewModel.username)
+                TextField("Email", text: $viewModel.email)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled(true)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
@@ -50,9 +50,9 @@ struct LoginView: View {
                         DefaultNetworkClient.shared.updateBaseURL(url)
                         serverAddress = address
                     }
-                    viewModel.login()
+                    viewModel.signin()
                 }) {
-                    Text(viewModel.isLoading ? "Logging in…" : "Login")
+                    Text(viewModel.isLoading ? "Signing in…" : "Sign In")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(.ultraThinMaterial)


### PR DESCRIPTION
## Summary
- update `APIEndpoint` to use sign-in/out and admin route changes
- modify `AuthService` and view models to use new methods
- update UI to prompt for email and sign in
- adjust UI tests for new labels

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687e2d0974a8832f8895b90c1332554a