### PR TITLE
Remove login server field

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MakerWorks-iOS is a SwiftUI application for interacting with the MakerWorks service. The project contains network clients, view models, and views for authentication, browsing models, requesting estimates, uploading prints, and managing local favorites.
 
-The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. The login screen includes a field for the server address and the value entered will be used for all API requests. You can still update the base URL programmatically via `DefaultNetworkClient` if needed.
+The app communicates with the MakerWorks backend at `https://api.makerworks.app` by default. You can update the base URL programmatically via `DefaultNetworkClient` if needed.
 
 ## Prerequisites
 - macOS with [Xcode](https://developer.apple.com/xcode/) **16.3** or later

--- a/Sources/App/MakerWorksApp.swift
+++ b/Sources/App/MakerWorksApp.swift
@@ -9,18 +9,12 @@ import SwiftUI
 
 @main
 struct MakerWorksApp: App {
-    @AppStorage("serverAddress") private var serverAddress: String?
     @State private var isLoggedIn: Bool = false
 
     var body: some Scene {
         WindowGroup {
             if !isLoggedIn {
                 LoginView()
-                    .onAppear {
-                        if let addr = serverAddress, let url = URL(string: addr) {
-                            DefaultNetworkClient.shared.updateBaseURL(url)
-                        }
-                    }
                     .onReceive(NotificationCenter.default.publisher(for: .didLogin)) { _ in
                         isLoggedIn = true
                     }

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -20,7 +20,7 @@ protocol NetworkClient {
 /// Default implementation of the NetworkClient
 final class DefaultNetworkClient: NetworkClient {
     static let shared = DefaultNetworkClient(
-        baseURL: URL(string: "http://127.0.0.1:8000")!,
+        baseURL: URL(string: "https://api.makerworks.app")!,
         authenticator: Authenticator.shared
     )
 

--- a/Sources/Tests/MakerWorksUITests/LoginUITests.swift
+++ b/Sources/Tests/MakerWorksUITests/LoginUITests.swift
@@ -18,7 +18,6 @@ final class LoginUITests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.staticTexts["Welcome to MakerWorks"].exists)
-        XCTAssertTrue(app.textFields["Server Address"].exists)
         XCTAssertTrue(app.textFields["Email"].exists)
         XCTAssertTrue(app.secureTextFields["Password"].exists)
         XCTAssertTrue(app.buttons["Sign In"].exists)

--- a/Sources/Views/LoginView.swift
+++ b/Sources/Views/LoginView.swift
@@ -9,8 +9,6 @@ import SwiftUI
 
 struct LoginView: View {
     @StateObject private var viewModel = LoginViewModel()
-    @AppStorage("serverAddress") private var serverAddress: String?
-    @State private var address: String = ""
 
     var body: some View {
         ZStack {
@@ -21,12 +19,6 @@ struct LoginView: View {
                 Text("Welcome to MakerWorks")
                     .font(.largeTitle)
                     .foregroundColor(.white)
-
-                TextField("Server Address", text: $address)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled(true)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
 
                 if let error = viewModel.errorMessage {
                     Text(error)
@@ -46,10 +38,6 @@ struct LoginView: View {
                     .padding(.horizontal)
 
                 Button(action: {
-                    if let url = URL(string: address) {
-                        DefaultNetworkClient.shared.updateBaseURL(url)
-                        serverAddress = address
-                    }
                     viewModel.signin()
                 }) {
                     Text(viewModel.isLoading ? "Signing in…" : "Sign In")
@@ -64,12 +52,6 @@ struct LoginView: View {
                 Spacer()
             }
             .padding()
-        }
-        .onAppear {
-            address = serverAddress ?? "https://api.makerworks.app"
-            if let addr = serverAddress, let url = URL(string: addr) {
-                DefaultNetworkClient.shared.updateBaseURL(url)
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- default API base url to production server
- remove server address storage & field from LoginView
- stop reading serverAddress in MakerWorksApp
- adjust UI tests and README

## Testing
- `xcodebuild -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6f43e41c832f8cdee684a297b8c4