### PR TITLE
Add splash animation before login

### DIFF
--- a/Sources/App/MakerWorksApp.swift
+++ b/Sources/App/MakerWorksApp.swift
@@ -10,10 +10,15 @@ import SwiftUI
 @main
 struct MakerWorksApp: App {
     @State private var isLoggedIn: Bool = false
+    @State private var showSplash: Bool = true
 
     var body: some Scene {
         WindowGroup {
-            if !isLoggedIn {
+            if showSplash {
+                SplashView {
+                    showSplash = false
+                }
+            } else if !isLoggedIn {
                 LoginView()
                     .onReceive(NotificationCenter.default.publisher(for: .didLogin)) { _ in
                         isLoggedIn = true

--- a/Sources/Views/SplashView.swift
+++ b/Sources/Views/SplashView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct SplashView: View {
+    @State private var animate = false
+    var onFinished: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+            PixelNozzleAnimation(animate: $animate)
+                .frame(width: 80, height: 80)
+        }
+        .onAppear {
+            animate = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                onFinished()
+            }
+        }
+    }
+}
+
+struct PixelNozzleAnimation: View {
+    @Binding var animate: Bool
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            let nozzleSize = width * 0.25
+            let filamentHeight = width * 0.1
+            let travel = width - nozzleSize
+
+            ZStack(alignment: .topLeading) {
+                Rectangle()
+                    .fill(Color.orange)
+                    .frame(width: animate ? travel : 0, height: filamentHeight)
+                    .offset(x: 0, y: nozzleSize + 4)
+                    .animation(.linear(duration: 5), value: animate)
+
+                Rectangle()
+                    .fill(Color.gray)
+                    .frame(width: nozzleSize, height: nozzleSize)
+                    .offset(x: animate ? travel : 0)
+                    .animation(.linear(duration: 5), value: animate)
+            }
+        }
+    }
+}
+
+#Preview {
+    SplashView(onFinished: {})
+}


### PR DESCRIPTION
## Summary
- add a `SplashView` with a simple 8‑bit style printing animation
- show `SplashView` for 5s before displaying `LoginView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687ec6db83cc832f9b7d6d115bdc9d3f

## Summary by Sourcery

Introduce a splash screen with a pixel-style animation displayed for 5 seconds before showing the login view.

New Features:
- Add SplashView with an 8-bit style printing animation
- Implement PixelNozzleAnimation as a reusable SwiftUI view

Enhancements:
- Add showSplash state and logic in MakerWorksApp to display SplashView before LoginView