### PR TITLE
Add sign up option on login

### DIFF
--- a/Sources/Tests/MakerWorksTests/SignupViewModelTests.swift
+++ b/Sources/Tests/MakerWorksTests/SignupViewModelTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import Combine
+@testable import MakerWorks
+
+final class SignupViewModelTests: XCTestCase {
+    var viewModel: SignupViewModel!
+    var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        viewModel = SignupViewModel(authService: MockAuthService())
+        cancellables = []
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        cancellables = nil
+        super.tearDown()
+    }
+
+    func testSignupSuccessPostsNotification() {
+        let expectation = expectation(forNotification: .didLogin, object: nil, handler: nil)
+        viewModel.email = "user@example.com"
+        viewModel.password = "secret"
+        viewModel.signup()
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+private class MockAuthService: AuthServiceProtocol {
+    func fetchCurrentUser() -> AnyPublisher<User, Error> { fatalError() }
+    func exchangeCodeForToken(code: String) -> AnyPublisher<User, Error> { fatalError() }
+    func signup(email: String, password: String) -> AnyPublisher<User, Error> {
+        let user = User(id: "1", email: email, username: "test", role: "user", isVerified: true)
+        return Just(user)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+    func signin(email: String, password: String) -> AnyPublisher<User, Error> { fatalError() }
+    func debugMe() -> AnyPublisher<User, Error> { fatalError() }
+    func adminUnlock(email: String) -> AnyPublisher<Void, Error> { fatalError() }
+    func signout() {}
+}

--- a/Sources/ViewModels/SignupViewModel.swift
+++ b/Sources/ViewModels/SignupViewModel.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Combine
+import os
+
+final class SignupViewModel: ObservableObject {
+    @Published var email: String = ""
+    @Published var password: String = ""
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
+    private var cancellables = Set<AnyCancellable>()
+    private let authService: AuthServiceProtocol
+    private let logger = Logger(subsystem: "techpunk.MakerWorks", category: "SignupViewModel")
+
+    init(authService: AuthServiceProtocol = AuthService()) {
+        self.authService = authService
+    }
+
+    /// Starts the sign-up process with email & password
+    func signup() {
+        logger.info("Attempting sign up")
+        self.isLoading = true
+        self.errorMessage = nil
+        authService.signup(email: email, password: password)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { [weak self] completion in
+                guard let self = self else { return }
+                self.isLoading = false
+                if case .failure(let error) = completion {
+                    self.errorMessage = error.localizedDescription
+                    self.logger.error("Sign up failed: \(error.localizedDescription)")
+                }
+            }, receiveValue: { [weak self] user in
+                guard let self = self else { return }
+                self.isLoading = false
+                if let uuid = UUID(uuidString: user.id) {
+                    self.logger.info("Sign up successful: \(uuid.uuidString)")
+                } else {
+                    self.logger.info("Sign up successful: \(user.id)")
+                }
+                NotificationCenter.default.post(name: .didLogin, object: nil)
+            })
+            .store(in: &cancellables)
+    }
+}

--- a/Sources/Views/SignUpView.swift
+++ b/Sources/Views/SignUpView.swift
@@ -1,15 +1,8 @@
-//
-//  LoginView.swift
-//  MakerWorks
-//
-//  Created by Stephen Chartrand on 2025-07-06.
-//
-
 import SwiftUI
 
-struct LoginView: View {
-    @StateObject private var viewModel = LoginViewModel()
-    @State private var showSignup = false
+struct SignUpView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var viewModel = SignupViewModel()
 
     var body: some View {
         ZStack {
@@ -17,7 +10,7 @@ struct LoginView: View {
 
             VStack(spacing: 24) {
                 Spacer()
-                Text("Welcome to MakerWorks")
+                Text("Create an Account")
                     .font(.largeTitle)
                     .foregroundColor(.white)
 
@@ -39,9 +32,9 @@ struct LoginView: View {
                     .padding(.horizontal)
 
                 Button(action: {
-                    viewModel.signin()
+                    viewModel.signup()
                 }) {
-                    Text(viewModel.isLoading ? "Signing in…" : "Sign In")
+                    Text(viewModel.isLoading ? "Signing up…" : "Sign Up")
                         .frame(maxWidth: .infinity)
                         .padding()
                         .background(.ultraThinMaterial)
@@ -50,17 +43,18 @@ struct LoginView: View {
                 .disabled(viewModel.isLoading)
                 .padding(.horizontal)
 
-                Button("Don't have an account? Sign Up") {
-                    showSignup = true
-                }
-                .padding(.horizontal)
-                .sheet(isPresented: $showSignup) {
-                    SignUpView()
-                }
-
                 Spacer()
             }
             .padding()
         }
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel") { dismiss() }
+            }
+        }
     }
+}
+
+#Preview {
+    SignUpView()
 }


### PR DESCRIPTION
## Summary
- create `SignupView` and `SignupViewModel`
- present SignUp sheet from `LoginView`
- add unit test for `SignupViewModel`

## Testing
- `swift test -q` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687ffc5674b0832f836d9055a4924dd0

## Summary by Sourcery

Add a sign-up flow by creating a dedicated view and view model, integrate it into the login screen, and cover the signup process with a unit test.

New Features:
- Introduce SignUpView and SignupViewModel for user account creation
- Add a sign-up button on the login screen that presents the SignUpView as a sheet

Tests:
- Add unit test for SignupViewModel to verify successful signup posts didLogin notification