### PR TITLE
Implement signout request and test

### DIFF
--- a/MakerWorks.xcodeproj/project.pbxproj
+++ b/MakerWorks.xcodeproj/project.pbxproj
@@ -45,8 +45,9 @@
 				Tests/MakerWorksTests/FavoritesManagerTests.swift,
 				Tests/MakerWorksTests/NetworkClientTests.swift,
 				Tests/MakerWorksTests/TokenStorageTests.swift,
-				Tests/MakerWorksTests/UploadEndpointTests.swift,
-				Tests/MakerWorksUITests/LoginUITests.swift,
+                                Tests/MakerWorksTests/UploadEndpointTests.swift,
+                                Tests/MakerWorksTests/AuthServiceTests.swift,
+                                Tests/MakerWorksUITests/LoginUITests.swift,
 			);
 			target = 4C9F23552E1B14B5007B3C2D /* MakerWorks */;
 		};
@@ -59,8 +60,9 @@
 				Tests/MakerWorksTests/FavoritesManagerTests.swift,
 				Tests/MakerWorksTests/NetworkClientTests.swift,
 				Tests/MakerWorksTests/TokenStorageTests.swift,
-				Tests/MakerWorksTests/UploadEndpointTests.swift,
-			);
+                                Tests/MakerWorksTests/UploadEndpointTests.swift,
+                                Tests/MakerWorksTests/AuthServiceTests.swift,
+                        );
 			target = 4C9F23622E1B14B6007B3C2D /* MakerWorksTests */;
 		};
 		4CE544E02E2E67830046196A /* Exceptions for "Sources" folder in "MakerWorksUITests" target */ = {

--- a/Sources/Networking/AuthService.swift
+++ b/Sources/Networking/AuthService.swift
@@ -20,6 +20,7 @@ protocol AuthServiceProtocol {
 
 final class AuthService: AuthServiceProtocol {
     private let client: NetworkClient
+    private var cancellables = Set<AnyCancellable>()
 
     init(client: NetworkClient = DefaultNetworkClient.shared) {
         self.client = client
@@ -50,6 +51,11 @@ final class AuthService: AuthServiceProtocol {
     }
 
     func signout() {
-        TokenStorage.shared.clear()
+        client.requestVoid(APIEndpoint.signout)
+            .sink(receiveCompletion: { [weak self] _ in
+                TokenStorage.shared.clear()
+                self?.cancellables.removeAll()
+            }, receiveValue: { _ in })
+            .store(in: &cancellables)
     }
 }

--- a/Sources/Tests/MakerWorksTests/AuthServiceTests.swift
+++ b/Sources/Tests/MakerWorksTests/AuthServiceTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import Combine
+@testable import MakerWorks
+
+final class AuthServiceTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        TokenStorage.shared.clear()
+    }
+
+    func testSignoutRequestsEndpointAndClearsStorage() {
+        let client = MockNetworkClient()
+        let service = AuthService(client: client)
+        TokenStorage.shared.saveAll(token: "t", email: "e", username: "u", groups: "g")
+        service.signout()
+        XCTAssertTrue(client.didCallSignout)
+        XCTAssertNil(TokenStorage.shared.getToken())
+        XCTAssertNil(TokenStorage.shared.getEmail())
+        XCTAssertNil(TokenStorage.shared.getUsername())
+        XCTAssertNil(TokenStorage.shared.getGroups())
+    }
+}
+
+private final class MockNetworkClient: NetworkClient {
+    var didCallSignout = false
+
+    func request<T>(_ endpoint: APIEndpoint) -> AnyPublisher<T, Error> where T : Decodable {
+        fatalError("not implemented")
+    }
+
+    func requestVoid(_ endpoint: APIEndpoint) -> AnyPublisher<Void, Error> {
+        if case .signout = endpoint {
+            didCallSignout = true
+        }
+        return Just(())
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
## Summary
- invoke APIEndpoint.signout before clearing TokenStorage
- keep subscription alive with cancellables
- add AuthServiceTests verifying signout behavior
- include new test file in Xcode project

## Testing
- `swift test --enable-test-discovery` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68801247e650832f90f13922ddd20339

## Summary by Sourcery

Enhance the AuthService signout method to call the signout API before clearing storage and manage Combine subscriptions, and add unit tests to verify the behavior.

Enhancements:
- Invoke APIEndpoint.signout in AuthService.signout before clearing TokenStorage
- Track and clear Combine cancellables after the signout request completes

Build:
- Include the new AuthServiceTests.swift file in the Xcode project configuration

Tests:
- Add AuthServiceTests to verify signout triggers the endpoint and clears stored tokens using a mock NetworkClient