### PR TITLE
Store tokens from AuthService responses

### DIFF
--- a/Sources/Models/AuthResponse.swift
+++ b/Sources/Models/AuthResponse.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Response returned by auth-related endpoints containing token and user details
+struct AuthResponse: Codable {
+    let accessToken: String
+    let email: String
+    let username: String
+    let groups: String?
+    let user: User
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case email
+        case username
+        case groups
+        case user
+    }
+}

--- a/Sources/Networking/AuthService.swift
+++ b/Sources/Networking/AuthService.swift
@@ -31,15 +31,39 @@ final class AuthService: AuthServiceProtocol {
     }
 
     func exchangeCodeForToken(code: String) -> AnyPublisher<User, Error> {
-        client.request(APIEndpoint.exchangeCode(code))
+        (client.request(APIEndpoint.exchangeCode(code)) as AnyPublisher<AuthResponse, Error>)
+            .handleEvents(receiveOutput: { response in
+                TokenStorage.shared.saveAll(token: response.accessToken,
+                                            email: response.email,
+                                            username: response.username,
+                                            groups: response.groups)
+            })
+            .map { $0.user }
+            .eraseToAnyPublisher()
     }
 
     func signup(email: String, password: String) -> AnyPublisher<User, Error> {
-        client.request(APIEndpoint.signup(email: email, password: password))
+        (client.request(APIEndpoint.signup(email: email, password: password)) as AnyPublisher<AuthResponse, Error>)
+            .handleEvents(receiveOutput: { response in
+                TokenStorage.shared.saveAll(token: response.accessToken,
+                                            email: response.email,
+                                            username: response.username,
+                                            groups: response.groups)
+            })
+            .map { $0.user }
+            .eraseToAnyPublisher()
     }
 
     func signin(email: String, password: String) -> AnyPublisher<User, Error> {
-        client.request(APIEndpoint.signin(email: email, password: password))
+        (client.request(APIEndpoint.signin(email: email, password: password)) as AnyPublisher<AuthResponse, Error>)
+            .handleEvents(receiveOutput: { response in
+                TokenStorage.shared.saveAll(token: response.accessToken,
+                                            email: response.email,
+                                            username: response.username,
+                                            groups: response.groups)
+            })
+            .map { $0.user }
+            .eraseToAnyPublisher()
     }
 
     func debugMe() -> AnyPublisher<User, Error> {

--- a/Sources/Tests/MakerWorksTests/AuthServiceAuthFlowTests.swift
+++ b/Sources/Tests/MakerWorksTests/AuthServiceAuthFlowTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import Combine
+@testable import MakerWorks
+
+final class AuthServiceAuthFlowTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        TokenStorage.shared.clear()
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testSigninStoresTokenAndUserInfo() {
+        let client = MockAuthClient()
+        let service = AuthService(client: client)
+
+        let exp = expectation(description: "signin")
+        var result: User?
+        service.signin(email: "e", password: "p")
+            .sink(receiveCompletion: { _ in }, receiveValue: { user in
+                result = user
+                exp.fulfill()
+            })
+            .store(in: &cancellables)
+
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertEqual(result?.id, client.user.id)
+        XCTAssertEqual(TokenStorage.shared.getToken(), "token")
+        XCTAssertEqual(TokenStorage.shared.getEmail(), client.user.email)
+        XCTAssertEqual(TokenStorage.shared.getUsername(), client.user.username)
+        XCTAssertEqual(TokenStorage.shared.getGroups(), "staff")
+    }
+
+    func testSignupStoresTokenAndUserInfo() {
+        let client = MockAuthClient()
+        let service = AuthService(client: client)
+
+        let exp = expectation(description: "signup")
+        service.signup(email: "e", password: "p")
+            .sink(receiveCompletion: { _ in exp.fulfill() }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertEqual(TokenStorage.shared.getToken(), "token")
+        XCTAssertEqual(TokenStorage.shared.getEmail(), client.user.email)
+        XCTAssertEqual(TokenStorage.shared.getUsername(), client.user.username)
+        XCTAssertEqual(TokenStorage.shared.getGroups(), "staff")
+    }
+
+    func testExchangeStoresTokenAndUserInfo() {
+        let client = MockAuthClient()
+        let service = AuthService(client: client)
+
+        let exp = expectation(description: "exchange")
+        service.exchangeCodeForToken(code: "abc")
+            .sink(receiveCompletion: { _ in exp.fulfill() }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertEqual(TokenStorage.shared.getToken(), "token")
+        XCTAssertEqual(TokenStorage.shared.getEmail(), client.user.email)
+        XCTAssertEqual(TokenStorage.shared.getUsername(), client.user.username)
+        XCTAssertEqual(TokenStorage.shared.getGroups(), "staff")
+    }
+
+    func testAuthenticatorUsesStoredValuesAfterSignin() {
+        let client = MockAuthClient()
+        let service = AuthService(client: client)
+        let exp = expectation(description: "signin")
+        service.signin(email: "e", password: "p")
+            .sink(receiveCompletion: { _ in exp.fulfill() }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp], timeout: 1.0)
+
+        var request = URLRequest(url: URL(string: "https://example.com")!)
+        Authenticator.shared.attachHeaders(to: &request)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Authentik-Email"), client.user.email)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Authentik-Username"), client.user.username)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "X-Authentik-Groups"), "staff")
+    }
+}
+
+private final class MockAuthClient: NetworkClient {
+    let user = User(id: "1", email: "a@b.com", username: "user", role: "member", isVerified: true)
+
+    func request<T>(_ endpoint: APIEndpoint) -> AnyPublisher<T, Error> where T : Decodable {
+        let response = AuthResponse(accessToken: "token", email: user.email, username: user.username, groups: "staff", user: user)
+        return Just(response as! T)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+
+    func requestVoid(_ endpoint: APIEndpoint) -> AnyPublisher<Void, Error> {
+        fatalError("not implemented")
+    }
+}


### PR DESCRIPTION
## Summary
- decode authentication responses into `AuthResponse`
- persist access token, email, username and groups in `TokenStorage`
- attach authentication headers automatically after sign-in/signup
- test auth flow storing tokens and header attachment

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6880152b28a4832fb4be60aeb4790604