### PR TITLE
Fix admin unlock endpoint path

### DIFF
--- a/Sources/Networking/APIEndpoint.swift
+++ b/Sources/Networking/APIEndpoint.swift
@@ -61,7 +61,7 @@ enum APIEndpoint {
             request.httpMethod = "GET"
 
         case let .adminUnlock(email):
-            url = baseURL.appendingPathComponent("/api/v1/admin/admin/unlock/")
+            url = baseURL.appendingPathComponent("/api/v1/admin/unlock/")
             request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/Sources/Tests/MakerWorksTests/AuthTests.swift
+++ b/Sources/Tests/MakerWorksTests/AuthTests.swift
@@ -17,4 +17,20 @@ final class AuthTests: XCTestCase {
             XCTFail("Request body missing")
         }
     }
+
+    func testAdminUnlockEndpointRequest() throws {
+        let baseURL = URL(string: "https://api.makerworks.app")!
+        let request = APIEndpoint.adminUnlock(email: "user@example.com").urlRequest(baseURL: baseURL)
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.makerworks.app/api/v1/admin/unlock/")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        if let body = request.httpBody,
+           let json = try JSONSerialization.jsonObject(with: body) as? [String: String] {
+            XCTAssertEqual(json["email"], "user@example.com")
+        } else {
+            XCTFail("Request body missing")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- update adminUnlock endpoint path
- add test verifying admin unlock request URL

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688018422cf4832f8754edb35d70609a

## Summary by Sourcery

Fix the duplicated segment in the admin unlock endpoint path and add a unit test to verify the constructed request

Bug Fixes:
- Correct the adminUnlock endpoint URL from /api/v1/admin/admin/unlock/ to /api/v1/admin/unlock/

Tests:
- Add a test to validate the admin unlock request’s URL, HTTP method, headers, and JSON body