### PR TITLE
Add admin API endpoints

### DIFF
--- a/Sources/Networking/APIEndpoint.swift
+++ b/Sources/Networking/APIEndpoint.swift
@@ -13,6 +13,8 @@ enum APIEndpoint {
     case currentUser
     case debugMe
     case adminUnlock(email: String)
+    case adminLock(email: String)
+    case adminUsers
     case uploadModel(data: Data, boundary: String)
     case listModels
     case estimate(parameters: EstimateParameters)
@@ -71,6 +73,23 @@ enum APIEndpoint {
             } catch {
                 fatalError("Failed to encode adminUnlock body: \(error)")
             }
+
+        case let .adminLock(email):
+            url = baseURL.appendingPathComponent("/api/v1/admin/lock/")
+            request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            let body = ["email": email]
+            do {
+                request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
+            } catch {
+                fatalError("Failed to encode adminLock body: \(error)")
+            }
+
+        case .adminUsers:
+            url = baseURL.appendingPathComponent("/api/v1/admin/users/")
+            request = URLRequest(url: url)
+            request.httpMethod = "GET"
 
         case let .uploadModel(data, boundary):
             url = baseURL.appendingPathComponent("/api/v1/upload/")

--- a/Sources/Networking/AuthService.swift
+++ b/Sources/Networking/AuthService.swift
@@ -15,6 +15,8 @@ protocol AuthServiceProtocol {
     func signin(email: String, password: String) -> AnyPublisher<User, Error>
     func debugMe() -> AnyPublisher<User, Error>
     func adminUnlock(email: String) -> AnyPublisher<Void, Error>
+    func adminLock(email: String) -> AnyPublisher<Void, Error>
+    func adminUsers() -> AnyPublisher<[User], Error>
     func signout()
 }
 
@@ -72,6 +74,14 @@ final class AuthService: AuthServiceProtocol {
 
     func adminUnlock(email: String) -> AnyPublisher<Void, Error> {
         client.requestVoid(APIEndpoint.adminUnlock(email: email))
+    }
+
+    func adminLock(email: String) -> AnyPublisher<Void, Error> {
+        client.requestVoid(APIEndpoint.adminLock(email: email))
+    }
+
+    func adminUsers() -> AnyPublisher<[User], Error> {
+        client.request(APIEndpoint.adminUsers)
     }
 
     func signout() {

--- a/Sources/Tests/MakerWorksTests/AuthTests.swift
+++ b/Sources/Tests/MakerWorksTests/AuthTests.swift
@@ -33,4 +33,28 @@ final class AuthTests: XCTestCase {
             XCTFail("Request body missing")
         }
     }
+
+    func testAdminLockEndpointRequest() throws {
+        let baseURL = URL(string: "https://api.makerworks.app")!
+        let request = APIEndpoint.adminLock(email: "user@example.com").urlRequest(baseURL: baseURL)
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.makerworks.app/api/v1/admin/lock/")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+
+        if let body = request.httpBody,
+           let json = try JSONSerialization.jsonObject(with: body) as? [String: String] {
+            XCTAssertEqual(json["email"], "user@example.com")
+        } else {
+            XCTFail("Request body missing")
+        }
+    }
+
+    func testAdminUsersEndpointRequest() throws {
+        let baseURL = URL(string: "https://api.makerworks.app")!
+        let request = APIEndpoint.adminUsers.urlRequest(baseURL: baseURL)
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.absoluteString, "https://api.makerworks.app/api/v1/admin/users/")
+    }
 }


### PR DESCRIPTION
## Summary
- extend `APIEndpoint` with `adminLock` and `adminUsers`
- support the new admin APIs in `AuthService`
- test URL construction for the new endpoints

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688018fc2de4832f952f0be22ce98584