### PR TITLE
Fix README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,31 +62,8 @@ open MakerWorks.xcodeproj
 3. Press **Run** to build and launch the app.
 
 ### Tests
-The repository includes unit and UI tests. Run them from Xcode with **Product → Test**.
-After installing the Swift toolchain (see below), you can also execute the tests
-from the command line with:
+The repository includes unit and UI tests. Run them from Xcode using **Product → Test**.
 
-```bash
-swift test
-```
-
-### CLI Setup (Swift Package Manager)
-
-To run the tests outside of Xcode you need a Swift toolchain with the Swift
-Package Manager. A helper script is provided for Ubuntu 20.04+:
-
-```bash
-sudo ./scripts/install_swift.sh
-```
-
-Once installation completes, open a new terminal (to update your `PATH`) and
-verify Swift is available:
-
-```bash
-swift --version
-```
-
-You can then execute the tests using `swift test` as shown above.
 
 ---
 


### PR DESCRIPTION
## Summary
- remove `swift test` commands from README
- keep instructions to run tests via Xcode

## Testing
- `xcodebuild test -project MakerWorks.xcodeproj -scheme MakerWorks -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68801a1d7ad8832f86b2381e0b9bd8e4

## Summary by Sourcery

Streamline README test instructions by removing Swift Package Manager CLI commands and setup guidance, leaving only Xcode-based testing steps.

Documentation:
- Remove 'swift test' command examples from the Tests section
- Eliminate CLI setup instructions and helper script references for running tests outside Xcode