### PR TITLE
Add ActivityKit live activity example

### DIFF
--- a/Sources/App/BackgroundTaskManager.swift
+++ b/Sources/App/BackgroundTaskManager.swift
@@ -1,0 +1,44 @@
+import ActivityKit
+import Foundation
+import SwiftUI
+
+/// Manages a background task and updates the Live Activity with progress.
+@MainActor
+final class BackgroundTaskManager: ObservableObject {
+    private var activity: Activity<BackgroundTaskAttributes>?
+    private var timer: Timer?
+    private var progress: Double = 0
+
+    /// Starts a simulated background task and Live Activity updates.
+    func start() {
+        let attributes = BackgroundTaskAttributes(taskName: "Processing")
+        let initialState = BackgroundTaskAttributes.ContentState(progress: 0)
+
+        do {
+            activity = try Activity.request(attributes: attributes, contentState: initialState)
+            startTimer()
+        } catch {
+            print("Failed to start activity: \(error)")
+        }
+    }
+
+    private func startTimer() {
+        timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { await self?.incrementProgress() }
+        }
+    }
+
+    private func incrementProgress() async {
+        guard let activity else { return }
+        progress += 0.02
+        if progress >= 1 {
+            progress = 1
+            await activity.end(using: .init(progress: progress), dismissalPolicy: .immediate)
+            timer?.invalidate()
+            timer = nil
+            self.activity = nil
+        } else {
+            await activity.update(using: .init(progress: progress))
+        }
+    }
+}

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -1,13 +1,20 @@
 import SwiftUI
 
+/// Demonstrates starting a background task with a Live Activity.
 struct ContentView: View {
+    @StateObject private var taskManager = BackgroundTaskManager()
+
     var body: some View {
-        Text("Hello, MakerWorks!")
-            .padding()
+        VStack(spacing: 20) {
+            Text("Hello, MakerWorks!")
+            Button("Start Background Task") {
+                taskManager.start()
+            }
+        }
+        .padding()
     }
 }
 
 #Preview {
     ContentView()
 }
-

--- a/Sources/BackgroundTaskWidget/BackgroundTaskWidget.swift
+++ b/Sources/BackgroundTaskWidget/BackgroundTaskWidget.swift
@@ -1,0 +1,56 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+// Live Activity widget displaying task progress and an animated gear
+struct BackgroundTaskWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: BackgroundTaskAttributes.self) { context in
+            BackgroundTaskLiveActivityView(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "gearshape.fill")
+                            .rotationEffect(.degrees(context.state.progress * 360))
+                        Text("\(Int(context.state.progress * 100))%")
+                            .monospacedDigit()
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: "gearshape.fill")
+                    .rotationEffect(.degrees(context.state.progress * 360))
+            } compactTrailing: {
+                Text("\(Int(context.state.progress * 100))%")
+                    .font(.footnote)
+                    .monospacedDigit()
+            } minimal: {
+                Image(systemName: "gearshape.fill")
+                    .rotationEffect(.degrees(context.state.progress * 360))
+            }
+        }
+    }
+}
+
+// Lock screen/notification UI
+struct BackgroundTaskLiveActivityView: View {
+    let context: ActivityViewContext<BackgroundTaskAttributes>
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "gearshape.fill")
+                .rotationEffect(.degrees(context.state.progress * 360))
+            Text("\(Int(context.state.progress * 100))%")
+                .bold()
+                .monospacedDigit()
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct BackgroundTaskWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        BackgroundTaskWidget()
+            .previewContext(WidgetPreviewContext(family: .systemExtraLarge))
+    }
+}

--- a/Sources/BackgroundTaskWidget/BackgroundTaskWidgetBundle.swift
+++ b/Sources/BackgroundTaskWidget/BackgroundTaskWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct BackgroundTaskWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        BackgroundTaskWidget()
+    }
+}

--- a/Sources/LiveActivities/BackgroundTaskActivity.swift
+++ b/Sources/LiveActivities/BackgroundTaskActivity.swift
@@ -1,0 +1,13 @@
+import ActivityKit
+import Foundation
+
+// Defines the Live Activity's attributes and dynamic state
+struct BackgroundTaskAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        /// Progress from 0.0 to 1.0
+        var progress: Double
+    }
+
+    /// Name of the task being processed
+    var taskName: String
+}


### PR DESCRIPTION
## Summary
- add ActivityKit attributes and manager
- implement animated-gear Live Activity widget
- demonstrate starting the activity in `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688026ee145c832fa8e1c9600c2ff3bb