### PR TITLE
Add Live Activity for processing tasks

### DIFF
--- a/Sources/App/ActivityManager.swift
+++ b/Sources/App/ActivityManager.swift
@@ -1,0 +1,58 @@
+import ActivityKit
+import Foundation
+
+/// Singleton responsible for managing the processing Live Activity.
+@MainActor
+final class ActivityManager: ObservableObject {
+    static let shared = ActivityManager()
+
+    private var activity: Activity<ProcessingAttributes>?
+    private var updateTask: Task<Void, Never>?
+    private var progress: Double = 0
+
+    private init() {}
+
+    /// Starts the Live Activity and begins simulating progress updates.
+    func startProcessing(taskName: String = "Processing") {
+        guard activity == nil else { return }
+        let attributes = ProcessingAttributes(taskName: taskName)
+        let content = ProcessingAttributes.ContentState(progress: 0)
+
+        do {
+            activity = try Activity.request(attributes: attributes, contentState: content)
+            startProgressLoop()
+        } catch {
+            print("Failed to start Live Activity: \(error)")
+        }
+    }
+
+    /// Cancels progress updates and ends the Live Activity.
+    func stop() {
+        Task { await endActivity() }
+    }
+
+    /// Periodically increments progress to demonstrate updates.
+    private func startProgressLoop() {
+        updateTask?.cancel()
+        updateTask = Task {
+            while progress < 1.0 && !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                progress = min(progress + 0.05, 1)
+                await activity?.update(using: .init(progress: progress))
+            }
+            if !Task.isCancelled {
+                await endActivity()
+            }
+        }
+    }
+
+    private func endActivity() async {
+        updateTask?.cancel()
+        updateTask = nil
+        if let activity {
+            await activity.end(using: .init(progress: progress), dismissalPolicy: .immediate)
+        }
+        self.activity = nil
+        progress = 0
+    }
+}

--- a/Sources/App/ContentView.swift
+++ b/Sources/App/ContentView.swift
@@ -1,17 +1,39 @@
 import SwiftUI
 
-/// Demonstrates starting a background task with a Live Activity.
+/// Demonstrates starting and stopping a Live Activity using ``ActivityManager``.
 struct ContentView: View {
-    @StateObject private var taskManager = BackgroundTaskManager()
+    @State private var isProcessing = false
+    @State private var gearAngle = 0.0
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("Hello, MakerWorks!")
-            Button("Start Background Task") {
-                taskManager.start()
+            Image(systemName: "gearshape.fill")
+                .rotationEffect(.degrees(gearAngle))
+                .opacity(isProcessing ? 1 : 0)
+                .animation(
+                    isProcessing ? .linear(duration: 1).repeatForever(autoreverses: false) : .default,
+                    value: gearAngle
+                )
+
+            Button(isProcessing ? "Stop Processing" : "Start Processing") {
+                if isProcessing {
+                    ActivityManager.shared.stop()
+                    isProcessing = false
+                } else {
+                    ActivityManager.shared.startProcessing(taskName: "Upload")
+                    isProcessing = true
+                    startGearAnimation()
+                }
             }
         }
         .padding()
+    }
+
+    private func startGearAnimation() {
+        gearAngle = 0
+        withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) {
+            gearAngle = 360
+        }
     }
 }
 

--- a/Sources/BackgroundTaskWidget/BackgroundTaskWidgetBundle.swift
+++ b/Sources/BackgroundTaskWidget/BackgroundTaskWidgetBundle.swift
@@ -2,8 +2,9 @@ import SwiftUI
 import WidgetKit
 
 @main
-struct BackgroundTaskWidgetBundle: WidgetBundle {
+struct MakerWorksWidgetBundle: WidgetBundle {
     var body: some Widget {
         BackgroundTaskWidget()
+        ProcessingLiveActivityWidget()
     }
 }

--- a/Sources/LiveActivities/ProcessingAttributes.swift
+++ b/Sources/LiveActivities/ProcessingAttributes.swift
@@ -1,0 +1,13 @@
+import ActivityKit
+import Foundation
+
+/// Attributes for the processing Live Activity.
+struct ProcessingAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        /// Progress from 0.0 to 1.0
+        var progress: Double
+    }
+
+    /// Name of the task (rendering, uploading, etc.)
+    var taskName: String
+}

--- a/Sources/ProcessingWidget/ProcessingLiveActivityWidget.swift
+++ b/Sources/ProcessingWidget/ProcessingLiveActivityWidget.swift
@@ -1,0 +1,60 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// A simple view that rotates a gear symbol periodically.
+private struct RotatingGear: View {
+    var progress: Double
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1)) { context in
+            let additional = context.date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: 1)
+            Image(systemName: "gearshape.fill")
+                .rotationEffect(.degrees(progress * 360 + additional * 360))
+        }
+    }
+}
+
+/// Widget showing processing progress in the Dynamic Island.
+struct ProcessingLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: ProcessingAttributes.self) { context in
+            HStack(spacing: 8) {
+                RotatingGear(progress: context.state.progress)
+                Text("\(Int(context.state.progress * 100))%")
+                    .bold()
+                    .monospacedDigit()
+            }
+            .padding(.horizontal)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    HStack(spacing: 4) {
+                        RotatingGear(progress: context.state.progress)
+                        Text("\(Int(context.state.progress * 100))%")
+                            .monospacedDigit()
+                    }
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.attributes.taskName)
+                        .font(.footnote)
+                }
+            } compactLeading: {
+                RotatingGear(progress: context.state.progress)
+            } compactTrailing: {
+                Text("\(Int(context.state.progress * 100))%")
+                    .font(.footnote)
+                    .monospacedDigit()
+            } minimal: {
+                RotatingGear(progress: context.state.progress)
+            }
+        }
+    }
+}
+
+struct ProcessingLiveActivityWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        ProcessingLiveActivityWidget()
+            .previewContext(WidgetPreviewContext(family: .systemExtraLarge))
+    }
+}


### PR DESCRIPTION
## Summary
- create `ActivityManager` singleton for starting/stopping Live Activities
- define `ProcessingAttributes` for ActivityKit
- implement `ProcessingLiveActivityWidget` with rotating gear
- integrate new widget in bundle
- update `ContentView` to demonstrate starting and stopping processing activity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688031c81d0c832f92418507018eb5ce

## Summary by Sourcery

Add Live Activity support for processing tasks, including a manager, attributes, widget, and demo UI

New Features:
- Add ActivityManager singleton to start and stop processing live activities
- Define ProcessingAttributes for the processing Live Activity
- Create ProcessingLiveActivityWidget with a rotating gear and Dynamic Island configuration
- Integrate the new live activity widget into the existing widget bundle
- Update ContentView to allow starting and stopping the processing activity with a rotating gear animation