### PR TITLE
Support local backend configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ open MakerWorks.xcodeproj
 2. Choose an iOS simulator or connect a device.
 3. Press **Run** to build and launch the app.
 
+#### Connecting to a local backend
+If you're running the API locally (for example at `http://localhost:8000`), set
+the `BACKEND_URL` environment variable in the run scheme to the local URL. The
+app will automatically use this value when built in Debug mode.
+
 ### Tests
 The repository includes unit and UI tests. Run them from Xcode using **Product → Test**.
 

--- a/Sources/Networking/NetworkClient.swift
+++ b/Sources/Networking/NetworkClient.swift
@@ -19,10 +19,29 @@ protocol NetworkClient {
 
 /// Default implementation of the NetworkClient
 final class DefaultNetworkClient: NetworkClient {
+    /// Shared instance used across the app
+    ///
+    /// The base URL defaults to the production API but can be overridden at
+    /// runtime by setting the `BACKEND_URL` environment variable. This makes it
+    /// easy to point the app at a local development server when running in the
+    /// simulator.
     static let shared = DefaultNetworkClient(
-        baseURL: URL(string: "https://api.makerworks.app")!,
+        baseURL: Self.resolveBaseURL(),
         authenticator: Authenticator.shared
     )
+
+    /// Determines the base URL for the shared client. In DEBUG builds this will
+    /// check for the `BACKEND_URL` environment variable and use it if valid.
+    /// Otherwise the production API URL is returned.
+    private static func resolveBaseURL() -> URL {
+        #if DEBUG
+        if let override = ProcessInfo.processInfo.environment["BACKEND_URL"],
+           let url = URL(string: override) {
+            return url
+        }
+        #endif
+        return URL(string: "https://api.makerworks.app")!
+    }
 
     /// Base API endpoint used when constructing requests
     ///

--- a/Sources/Resources/Info/Info.plist
+++ b/Sources/Resources/Info/Info.plist
@@ -37,10 +37,15 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>UIApplicationSceneManifest</key>
-	<dict>
-		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
-	</dict>
+        <key>UIApplicationSceneManifest</key>
+        <dict>
+                <key>UIApplicationSupportsMultipleScenes</key>
+                <false/>
+        </dict>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+                <key>NSAllowsArbitraryLoads</key>
+                <true/>
+        </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow overriding the API base URL using the `BACKEND_URL` environment variable
- permit HTTP connections in Info.plist for debugging
- document how to point the app at a local backend

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6886a18c58bc832f96f884881a916790