### PR TITLE
Update Liquid Glass theme

### DIFF
--- a/Sources/Views/LoginView.swift
+++ b/Sources/Views/LoginView.swift
@@ -43,10 +43,9 @@ struct LoginView: View {
                 }) {
                     Text(viewModel.isLoading ? "Signing in…" : "Sign In")
                         .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(.ultraThinMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 20))
                 }
+                .buttonStyle(PlainButtonStyle())
+                .liquidGlass(cornerRadius: 20)
                 .disabled(viewModel.isLoading)
                 .padding(.horizontal)
 

--- a/Sources/Views/SignUpView.swift
+++ b/Sources/Views/SignUpView.swift
@@ -36,10 +36,9 @@ struct SignUpView: View {
                 }) {
                     Text(viewModel.isLoading ? "Signing up…" : "Sign Up")
                         .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(.ultraThinMaterial)
-                        .clipShape(RoundedRectangle(cornerRadius: 20))
                 }
+                .buttonStyle(PlainButtonStyle())
+                .liquidGlass(cornerRadius: 20)
                 .disabled(viewModel.isLoading)
                 .padding(.horizontal)
 

--- a/Sources/Views/modifiers/LiquidGlassModifier.swift
+++ b/Sources/Views/modifiers/LiquidGlassModifier.swift
@@ -1,17 +1,35 @@
 import SwiftUI
 
 struct LiquidGlassModifier: ViewModifier {
+    var cornerRadius: CGFloat = 12
+    var shadowRadius: CGFloat = 1
+    var padding: CGFloat = 12
+
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         content
-            .padding()
-            .background(.ultraThinMaterial)
-            .cornerRadius(12)
-            .shadow(radius: 1)
+            .padding(padding)
+            .background(
+                .ultraThinMaterial,
+                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(Color.white.opacity(colorScheme == .dark ? 0.15 : 0.3), lineWidth: 0.5)
+            )
+            .shadow(color: Color.black.opacity(0.2), radius: shadowRadius, x: 0, y: 1)
     }
 }
 
 extension View {
-    func liquidGlass() -> some View {
-        modifier(LiquidGlassModifier())
+    func liquidGlass(cornerRadius: CGFloat = 12, shadowRadius: CGFloat = 1, padding: CGFloat = 12) -> some View {
+        modifier(
+            LiquidGlassModifier(
+                cornerRadius: cornerRadius,
+                shadowRadius: shadowRadius,
+                padding: padding
+            )
+        )
     }
 }


### PR DESCRIPTION
## Summary
- tweak LiquidGlassModifier to allow customization and add subtle stroke
- restyle login and signup buttons to use liquidGlass()

## Testing
- `swift --version`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a2ecdc74832f943559a23ea56690

## Summary by Sourcery

Enhance the LiquidGlassModifier with customizable styling and apply the updated liquidGlass style to authentication buttons

Enhancements:
- Parameterize corner radius, shadow radius, and padding in LiquidGlassModifier
- Add a subtle stroke overlay with dynamic opacity based on the color scheme
- Replace manual background styling on login and signup buttons with PlainButtonStyle and the new liquidGlass modifier