### PR TITLE
Add brand palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ MakerWorks iOS is a **next-gen app for browsing, hosting, and managing 3D models
 - 🧼 Clean architecture
 - 🎨 VisionOS-inspired design language
 
+## 🎨 Brand Palette
+
+- **Primary (Bright Orange)**: `#FF6A1F`
+- **Secondary (Black)**: `#121212`
+- **Accent (Silver)**: `#C0C0C0`
+- **Background/Neutral (White)**: `#FFFFFF`
+
+### Gradient Options
+
+- **Orange → Silver**: `linear-gradient(135deg, #FF6A1F 0%, #C0C0C0 100%)`
+- **Black → Orange (Dark Mode)**: `linear-gradient(180deg, #121212 0%, #FF6A1F 100%)`
+- **White → Silver (Light Mode)**: `linear-gradient(180deg, #FFFFFF 0%, #C0C0C0 100%)`
+
 ---
 
 ## 🚀 Getting Started


### PR DESCRIPTION
## Summary
- document MakerWorks Industrial Pro palette in the README

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891357aa3c832f955640fc5c734bd1

## Summary by Sourcery

Document the MakerWorks Industrial Pro brand palette in the README with color values and gradient options

Documentation:
- Add Brand Palette section to README with primary, secondary, accent, and background color definitions
- Include gradient options for light and dark mode in the brand guidelines